### PR TITLE
remove language about GPUs

### DIFF
--- a/01-lightgbm.ipynb
+++ b/01-lightgbm.ipynb
@@ -114,7 +114,7 @@
    "source": [
     "### Monitor Resource Usage\n",
     "\n",
-    "This tutorial aims to teach you how to take advantage of multiple GPUs for data science workflows. To prove to yourself that Dask is taking advantage of the resources in the cluster, it's important to understand how to monitor that utilization while your code is running.\n",
+    "This tutorial aims to teach you how to take advantage of multiple machines for data science workflows. To prove to yourself that Dask is taking advantage of the resources in the cluster, it's important to understand how to monitor that utilization while your code is running.\n",
     "\n",
     "Print the `cluster` object in a notebook renders a widget that shows the number of workers, available CPU and memory, and a dashboard link."
    ]


### PR DESCRIPTION
The notebook for this workshop is a CPU-only example, and the "Monitoring Resources" section currently has some inaccurate language about how the tutorial tries to teach you to use multiple GPUs.